### PR TITLE
Adds helpful description to egon-server CLI

### DIFF
--- a/egon_server/cli.py
+++ b/egon_server/cli.py
@@ -20,17 +20,17 @@ MIGRATIONS_DIR = Path(__file__).parent / 'migrations'
 class Parser(ArgumentParser):
     """Defines the command line interface and handles command line argument parsing"""
 
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self) -> None:
         """Define the command line interface"""
 
-        super().__init__(*args, **kwargs)
+        super().__init__(prog='egon-server', description='Administrative utility for the Egon API server.')
         self.add_argument('--version', action='version', version=__version__)
-        self.subparsers = self.add_subparsers(parser_class=ArgumentParser, required=True)
+        subparsers = self.add_subparsers(parser_class=ArgumentParser, required=True)
 
-        migrate = self.subparsers.add_parser('migrate')
+        migrate = subparsers.add_parser('migrate', description='Migrate the database schema to the latest version.')
         migrate.set_defaults(action=Application.migrate_db)
 
-        serve = self.subparsers.add_parser('serve')
+        serve = subparsers.add_parser('serve', description='Launch a new API server instance.')
         serve.set_defaults(action=Application.serve_api)
         serve.add_argument('--host', type=str, default=DEFAULT_HOST, help='the hostname to listen on')
         serve.add_argument('--port', type=int, default=DEFAULT_PORT, help='the port of the webserver')
@@ -105,10 +105,7 @@ class Application:
     def execute(cls) -> None:
         """Parse command line arguments and run the application"""
 
-        parser = Parser(
-            prog='egon-server',
-            description='Administrative utility for the Egon backend server')
-
+        parser = Parser()
         args = vars(parser.parse_args())
         action = args.pop('action')
         action(**args)


### PR DESCRIPTION
The CLI subparsers were missing descriptions. I've added helpful descriptions to the base command in addition to the `migrate` and `serve` sub-commands.