### PR TITLE
Impliment custom 404/500 error handling.

### DIFF
--- a/egon_server/api.py
+++ b/egon_server/api.py
@@ -21,11 +21,17 @@ class AppFactory:
 
         flask_app = Flask(*args, import_name=import_name, **kwargs)
 
+        # Create a new API instance while protecting the Flask error handlers. See:
+        # https://github.com/flask-restful/flask-restful/issues/280#issuecomment-280648790
+        handle_exception = flask_app.handle_exception
+        handle_user_exception = flask_app.handle_user_exception
         api = Api(flask_app)
+        flask_app.handle_exception = handle_exception
+        flask_app.handle_user_exception = handle_user_exception
+
         api.add_resource(resources.common.Description, '/')
         api.add_resource(resources.common.Health, '/health')
-
-        cls.add_v1_endpoints(api, endpoint_root='/V1')
+        cls.add_v1_endpoints(api, endpoint_root='/v1')
         return flask_app
 
     @staticmethod
@@ -40,5 +46,5 @@ class AppFactory:
 
         endpoint_root = cls._clean_endpoint_root(endpoint_root)
         api.add_resource(resources.v1.Version, f'{endpoint_root}/version')
-        api.add_resource(resources.v1.Pipeline, f'{endpoint_root}pipeline/<string:pipelineId>')
+        api.add_resource(resources.v1.Pipeline, f'{endpoint_root}/pipeline/<string:pipelineId>')
         api.add_resource(resources.v1.Node, f'{endpoint_root}/node/<string:nodeId>')

--- a/egon_server/cli.py
+++ b/egon_server/cli.py
@@ -4,7 +4,7 @@ from argparse import ArgumentParser
 from pathlib import Path
 
 import waitress
-from flask import Flask
+from flask import Flask, jsonify
 from flask_alembic import Alembic
 
 from . import __version__
@@ -38,6 +38,22 @@ class Parser(ArgumentParser):
 
 class Application:
     """Entry point for instantiating and executing the application"""
+
+    @staticmethod
+    def __initialize_errors(app: Flask) -> None:
+        """Initialize custom flask error handling
+
+        Args:
+            app: The Flask application to initialize
+        """
+
+        @app.errorhandler(404)
+        def page_not_found(*args):
+            """Return a 404 error as a JSON response"""
+
+            return jsonify({'error': 404, 'message': 'The requested resource could not be found.'})
+
+        app.config['PROPAGATE_EXCEPTIONS'] = True
 
     @staticmethod
     def __initialize_db(app: Flask) -> None:
@@ -74,6 +90,7 @@ class Application:
 
         cls.__initialize_db(app)
         cls.__initialize_alembic(app)
+        cls.__initialize_404(app)
 
     @classmethod
     def migrate_db(cls, schema_version: str = __db_version__) -> None:


### PR DESCRIPTION
Flask makes it pretty easy to implement custom error handling, but there are some complications when the `flask_restful` library is added to the mix. It turns out `flask_restful` uses it's own error handlers instead of relying on the ones configured with `flask`. There is a lengthy issue on the topic [here](https://github.com/flask-restful/flask-restful/issues/280). I've implemented one of the work arounds from the linked thread to ensure all 404/500 errors are presented the same.