### PR TITLE
Fix directory does not exist warning

### DIFF
--- a/egon_server/settings.py
+++ b/egon_server/settings.py
@@ -7,7 +7,11 @@ Order of priority when resolving application settings:
   4. Default values defined by the ``Settings`` class
 """
 
+from pathlib import Path
+
 from pydantic import BaseSettings, Field
+
+_SECRETS_DIR = Path('/etc/egon_server/secrets')
 
 
 class Settings(BaseSettings):
@@ -23,6 +27,10 @@ class Settings(BaseSettings):
     class Config:
         """Configure settings parsing options"""
 
+        allow_mutation = False
         env_prefix = "EGON_"
         case_sensitive = False
-        secrets_dir = '/etc/egon_server/secrets'
+
+        # Only look for secrets if the exits - avoids pydantic warnings/errors
+        if _SECRETS_DIR.exists():
+            secrets_dir = _SECRETS_DIR


### PR DESCRIPTION
The application looks for secret values in the `/etc/egon_server/secrets` directory at startup. If the directory does not exist, `pydantic` raises the following warning:

```
/home/djperrefort/Github/server/egon_server/cli.py:50: UserWarning: directory "/etc/egon_server/secrets" does not exist
  s = Settings()
```

This warning is harmless but annoying. This PR fixes the issue by only referencing the secrets directory if the directory already exists. 