### PR TITLE
Disable auto creation of migrations directory

### DIFF
--- a/egon_server/cli.py
+++ b/egon_server/cli.py
@@ -77,7 +77,7 @@ class Application:
         """
 
         # Make sure alembic identifies migration scripts in the correct location
-        Alembic(app).init_app(app)
+        Alembic(app, run_mkdir=False).init_app(app)
         app.config['ALEMBIC']['script_location'] = str(MIGRATIONS_DIR)
 
     @classmethod


### PR DESCRIPTION
When running the `egon-server` command, a `migrations` directory is automatically created by Alembic. This extra directory is unnecessary so I've disabled the behavior by specifying `run_mkdir=False`.