### PR TITLE
Adds placeholder docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,6 @@ MANIFEST
 
 # Contract testing with hypothesis
 .hypothesis
+
+# Compiled documentation
+site/

--- a/docs/coming_soon.md
+++ b/docs/coming_soon.md
@@ -1,0 +1,11 @@
+---
+hide:
+- navigation
+- toc
+---
+
+# Coming Soon
+
+Technical documentation not available for this product yet.
+
+Rest assured publishing up-to-date documentation is a high priority and is under active development.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,3 @@
+site_name: egon
+nav:
+  - Overview: coming_soon.md


### PR DESCRIPTION
I'm building out the project website using mkdocs and the website repo needs to have some kind of documentation to pull from GitHub repository. I'm adding some placeholder documentation for now. I'll go back and fill in the content later on.